### PR TITLE
fix(selenium): fix search_product method when searching for one product

### DIFF
--- a/lib/apress/selenium_products/spec/company_site/eti/product_creation_spec.rb
+++ b/lib/apress/selenium_products/spec/company_site/eti/product_creation_spec.rb
@@ -82,7 +82,7 @@ describe 'ЕТИ' do
 
         @product = @cs_eti_table_products.add_product(@fields)
         @cs_eti_table_products.copy_product(@product)
-        @cs_eti_header.search_product(@fields[:name], exact: true, operation: :copy)
+        @cs_eti_header.search_product(@fields[:name], exact: true, expected_count: 2)
       end
 
       it 'отобразится 2 идентичных товара' do

--- a/lib/apress/selenium_products/version.rb
+++ b/lib/apress/selenium_products/version.rb
@@ -2,6 +2,6 @@
 
 module Apress
   module SeleniumProducts
-    VERSION = '1.2.0'
+    VERSION = '1.2.1'
   end
 end

--- a/lib/pages/company_site/eti/header.rb
+++ b/lib/pages/company_site/eti/header.rb
@@ -20,24 +20,25 @@ module CompanySite
         search_button
         wait_render_table
 
+        expected_count = options[:expected_count] || 1
         table_products = CompanySite::ETI::Table::Products.new
         max_attempts = 10
 
-        case options [:operation]
-        when :copy
-          max_attempts.times do
-            break if table_products.products_elements.size >= 2
+        max_attempts.times do
+          search_button
+          wait_render_table
 
-            search_button
-            wait_render_table
-            # Для синхронизации в среднем требуется около 1 минуты,
-            # чтобы товар после создания появился в индексе эластика
-            # Для достоверности увеличили слип до 10 секунд после каждой попытки повторного поиска,
-            # чтобы скопированный товар точно появился в ЕТИ
-            sleep 10
-          end
-          raise "Товары не отобразились после #{max_attempts} повторных поисков" if
-            table_products.string_no_products? || table_products.products_elements.size < 2
+          break if table_products.products_elements.size >= expected_count
+
+          # Для синхронизации в среднем требуется около 1 минуты,
+          # чтобы товар после создания появился в индексе эластика
+          # Для достоверности увеличили слип до 10 секунд после каждой попытки повторного поиска,
+          # чтобы скопированный товар точно появился в ЕТИ
+          sleep 10
+        end
+
+        if table_products.string_no_products? || table_products.products_elements.size < expected_count
+          raise "Товары не отобразились после #{max_attempts} повторных поисков"
         end
       end
 


### PR DESCRIPTION
- Исправил метод поиска `search_product`.
После [правок](https://github.com/abak-press/apress-selenium_products/pull/69) падал тест, когда после создания товара ожидаем увидеть 1 товар. Ретрай работал только в случае когда в таблице не отобразилось 2 и более товара при копировании. Если товары отобразились ретрай прекращался.
- Сейчас по умолчанию ретрай будет работать пока не отобразится 1 товар. А если в параметрах `expected_count` указать количество товаров которое ожидается, то повторный поиск будет работать пока не появится нужное количество товаров. То есть операция `copy` для определенного теста, была заменена на количество ожидаемых товаров в тесте.